### PR TITLE
Add symfony process 4.2 support back

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.2",
-        "symfony/process": "^5.0"
+        "symfony/process": "^4.2|^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "9.1.4"


### PR DESCRIPTION
| Q                  | A
| ------------------ | ---
| Bug fix?           | no
| New feature?       | no
| BC breaks?         | no
| Deprecations?      | no
| Fixed tickets      | N/A
| Related issues/PRs | N/A
| License            | MIT

#### What's in this PR?

Add symfony process 4.2 support back for backward compatible.

#### Why?

Which problem does the PR fix?
The symfony process version requirement has updated since v1.0.2 to `^5.0`, for backward compatible i added `^4.2` back to the requirement.